### PR TITLE
First pass of interpreter optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A <- i10; A
 * REPL
 * More!
 * How to express operations like map by themselves.
+* Is assignment really just an expression, or is it a statement?
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ A <- i10; A
 * More!
 * How to express operations like map by themselves.
 * Is assignment really just an expression, or is it a statement?
+* Interpreter should operate only with identifiers; move all value operation to the pretty printer.
+* Change {var, _, _} to {var, _}
 
 ## Copyright
 

--- a/src/ensemble_interpreter.erl
+++ b/src/ensemble_interpreter.erl
@@ -66,27 +66,46 @@ eval([Stmt|Stmts], State0) ->
 %% evaluated and assigned to the variable on the lhs; the variable on
 %% the lhs may not exist, so the variable needs to first be delcared.
 %%
-statement({update, {var, _, Variable}, Expression},
-          #state{actor=Actor, variables=Variables0}=State0) ->
+statement({update, {var, _, Variable}, Expression}, #state{actor=Actor}=State0) ->
     %% Create a new variable.
     {ok, _} = lasp:declare(Variable, ?SET),
 
     %% Evaluate the expression.
     case expression(Expression, State0) of
-        %% If the result of the expression needs to spawn a function to
-        %% bind a value to our variable, such as for a map and fold;
-        %% then return a closure that can be called immediately with the
-        %% variable to bind to.
-        {Function, State1} when is_function(Function) ->
-            Function(Variable, State1);
-        %% Else, if we get a value back, we can directly bind.
-        {Value, State1} ->
+        %% We got back the identifier of a variable that contains the
+        %% state that we want.
+        {{var, TheirId}, #state{variables=Variables0}=State1} ->
+            lager:info("Original identifier: ~p value: ~p",
+                       [Variable, lasp_type:query(?SET, Variable)]),
+            lager:info("Received identifier: ~p value: ~p",
+                       [TheirId, lasp_type:query(?SET, TheirId)]),
+
+            %% Bind our new variable directly to the shadow variable.
+            ok = lasp:bind_to(Variable, TheirId),
+
+            %% Wait for new variable to change from bottom state and
+            %% return the result.
+            {ok, {_, _, _, V1}} = lasp:read(Variable, {strict, undefined}),
+            Value = lasp_type:value(?SET, V1),
+            Variables = dict:store(Variable, V1, Variables0),
+
+            %% Return value and updated cache.
+            {Value, State1#state{variables=Variables}};
+
+        %% Else, we got back an literal value that we can directly bind
+        %% to the variable.
+        {Literal, #state{variables=Variables0}=State1} ->
             {ok, {_, _, _, V}} = lasp:update(Variable,
-                                            {add_all, Value},
+                                            {add_all, Literal},
                                             Actor),
+
+            %% Return current non-CRDT value to the user.
             V1 = lasp_type:value(?SET, V),
+
+            %% Cache last observed value.
             Variables = dict:store(Variable, V, Variables0),
             {V1, State1#state{variables=Variables}}
+
     end;
 %% Otherwise, the statement must be an expression that evaluates to a
 %% value that will be returned to the user.  Attempt to evaluate this
@@ -108,50 +127,72 @@ expression({query, {var, _, Variable}}, #state{variables=Variables0}=State) ->
             undefined
     end,
     {ok, {_, _, _, Value}} = lasp:read(Variable, Previous),
+    %% @todo: Write back newest value?
     {lasp_type:value(?SET, Value), State};
-expression({map, {var, _, Var}, {function, {Function0, _}}, Val}, State0) ->
-    Fun = fun(Variable, #state{variables=Variables0}=State) ->
 
-            %% Generate an Erlang anonymous function.
-            Function = case Function0 of
-                '+' ->
-                    fun(X) -> X + Val end;
-                '*' ->
-                    fun(X) -> X * Val end
-            end,
+%% When a process call is received, create a shadow variable to store
+%% the results of the map operation and return the identifier to the
+%% caller of map: it's their decision whether to query and return the
+%% result to the user, or assign the variable to another variable in the
+%% system.
+%%
+expression({process,
+            {map, {var, _, Source}, {function, {Function0, _}}, Val}},
+           #state{variables=Variables0}=State0) ->
 
-            %% Produce a closure that will be executed for the map
-            %% operation.
-            ok = lasp:map(Var, Function, Variable),
-
-            %% If we perform an operation on a variable, such as a map,
-            %% we know the value is going to change.  Therefore, modify
-            %% our cache of known values to show that the next read
-            %% operation should be strict, to guarantee
-            %% read-your-own-writes.
-            Previous = case dict:find(Variable, Variables0) of
-                {ok, V} ->
-                    V;
-                _ ->
-                    undefined
-            end,
-            Variables = dict:store(Variable, {strict, Previous}, Variables0),
-            {Previous, State#state{variables=Variables}}
-
+    %% Generate an Erlang anonymous function.
+    Function = case Function0 of
+        '+' ->
+            fun(X) -> X + Val end;
+        '*' ->
+            fun(X) -> X * Val end
     end,
-    {Fun, State0};
+
+    %% Create a shadow variable used to store the result of the fold
+    %% operation; this will get an anonymous global variable.
+    %%
+    {ok, {Destination, _, _, _}} = lasp:declare(?SET),
+    lager:info("Created shadow variable: ~p", [Destination]),
+
+    %% Execute the map operation.
+    ok = lasp:map(Source, Function, Destination),
+    lager:info("Current value of source: ~p", [lasp_type:query(?SET, Source)]),
+
+    %% If we perform an operation on a variable, such as a map,
+    %% we know the value is going to change.  Therefore, modify
+    %% our cache of known values to show that the next read
+    %% operation should be strict, to guarantee
+    %% read-your-own-writes.
+    Previous = case dict:find(Destination, Variables0) of
+        {ok, V} ->
+            V;
+        _ ->
+            undefined
+    end,
+    Variables = dict:store(Destination, {strict, Previous}, Variables0),
+
+    %% Return variable.
+    {{var, Destination}, State0#state{variables=Variables}};
 expression([Expr|Exprs], State0) ->
     {Value, State} = expression(Expr, State0),
     [Value|expression(Exprs, State)];
 expression(V, State) when is_integer(V) ->
     {V, State};
+expression({var, Variable}, #state{variables=_Variables0}=State0) ->
+    %% @todo: Cache here?
+    Value = lasp_type:query(?SET, Variable),
+    {Value, State0};
 expression({iota, V}, State) ->
     {lists:seq(1, V), State};
-expression(Expr, State) ->
+expression(Expr, _State) ->
     lager:info("Expression not caught: ~p", [Expr]),
-    {Expr, State}.
+    exit(badarg).
 
 %% @private
+pp({var, Variable}) ->
+    Value = lasp_type:query(?SET, Variable),
+    lager:info("Received value: ~p", [Value]),
+    pp(Value);
 pp(List) when is_list(List) ->
     list_to_binary("{ " ++
                    [io_lib:format("~p ", [Item]) || Item <- List] ++

--- a/src/ensemble_parser.yrl
+++ b/src/ensemble_parser.yrl
@@ -18,8 +18,8 @@ statement -> var '<-' expression : {update, '$1', '$3'}.
 statement -> expression : '$1'.
 
 expression -> 'i' integer : {iota, unwrap('$2')}.
-expression -> var function expression : {map, '$1', '$2', '$3'}.
-expression -> function '/' expression : {foldr, '$1', '$3'}.
+expression -> var function expression : {process, {map, '$1', '$2', '$3'}}.
+expression -> function '/' expression : {process, {foldr, '$1', '$3'}}.
 expression -> var : {query, '$1'}.
 expression -> int_list : '$1'.
 expression -> integer : unwrap('$1').

--- a/test/ensemble_SUITE.erl
+++ b/test/ensemble_SUITE.erl
@@ -33,7 +33,8 @@
 %% tests
 -export([iota_test/1,
          map_plus_test/1,
-         map_times_test/1]).
+         map_times_test/1,
+         map_without_assignment/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -60,7 +61,8 @@ all() ->
     [
      iota_test,
      map_plus_test,
-     map_times_test
+     map_times_test,
+     map_without_assignment
     ].
 
 %% ===================================================================
@@ -86,5 +88,11 @@ map_plus_test(_Config) ->
 %% @doc Verify the map behaviour.
 map_times_test(_Config) ->
     Program2 = io_lib:format("A <- i5; B <- A*2; B", []),
+    <<"{ 2 4 6 8 10 }">> = ?INTERPRETER:eval(Program2),
+    ok.
+
+%% @doc Verify the map behaviour.
+map_without_assignment(_Config) ->
+    Program2 = io_lib:format("A <- i5; A*2", []),
     <<"{ 2 4 6 8 10 }">> = ?INTERPRETER:eval(Program2),
     ok.


### PR DESCRIPTION
Rewrite the interpreter to use shadow variables for any process based
operations, therefore allowing the language to appear purely functional.
Treat processes as expressions that evaluate to their current value.
